### PR TITLE
Identifying Enterprise Owners in Github

### DIFF
--- a/cartography/data/jobs/cleanup/github_users_cleanup.json
+++ b/cartography/data/jobs/cleanup/github_users_cleanup.json
@@ -18,6 +18,11 @@
     "query": "MATCH (:GitHubUser)-[r:MEMBER_OF]->(:GitHubOrganization) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:GitHubUser)-[r:UNAFFILIATED]->(:GitHubOrganization) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "iterative": true,
+    "iterationsize": 100
   }],
   "name": "cleanup GitHub users data"
 }

--- a/cartography/intel/github/users.py
+++ b/cartography/intel/github/users.py
@@ -202,7 +202,8 @@ def load_unaffiliated_owners(
     Note the subtle differences between what is loaded here and what in load_organization_users:
     1. The user-org relationship is set to UNAFFILIATED instead of MEMBER_OF.
     2. 'role' is not set: these users have no role in the organization (i.e. they are neither 'MEMBER' nor 'ADMIN').
-    2. 'has_2fa_enabled' is not set: it is unavailable from the GraphQL query for these owners
+    3. 'has_2fa_enabled' is not set: it is unavailable from the GraphQL query for these owners
+    4. 'is_enterprise_owner' is always set to TRUE
 
     If the user does already exist in the graph (perhaps they are members of other orgs) then this merge will
     update the user's node but leave 'role' and 'has_2fa_enabled' untouched.

--- a/docs/root/modules/github/schema.md
+++ b/docs/root/modules/github/schema.md
@@ -131,10 +131,10 @@ Representation of a single GitHubUser [user object](https://developer.github.com
 | has_2fa_enabled | Whether the user has 2-factor authentication enabled |
 | role | Either 'ADMIN' (denoting that the user is an owner of a Github organization) or 'MEMBER' |
 | is_site_admin | Whether the user is a site admin |
-| permission | Only present if the user is an [outside collaborator](https://docs.github.com/en/graphql/reference/objects#repositorycollaboratorconnection) of this repo.
-`permission` is either ADMIN, MAINTAIN, READ, TRIAGE, or WRITE ([ref](https://docs.github.com/en/graphql/reference/enums#repositorypermission)).
-| email | The user's publicly visible profile email.
-| company | The user's public profile company.
+| is_enterprise_owner | Whether the user is an [enterprise owner](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners) |
+| permission | Only present if the user is an [outside collaborator](https://docs.github.com/en/graphql/reference/objects#repositorycollaboratorconnection) of this repo.  `permission` is either ADMIN, MAINTAIN, READ, TRIAGE, or WRITE ([ref](https://docs.github.com/en/graphql/reference/enums#repositorypermission)). |
+| email | The user's publicly visible profile email. |
+| company | The user's public profile company. |
 
 
 #### Relationships
@@ -150,6 +150,12 @@ WRITE, MAINTAIN, TRIAGE, and READ ([Reference](https://docs.github.com/en/graphq
 
     ```
     (GitHubUser)-[:OUTSIDE_COLLAB_{ACTION}]->(GitHubRepository)
+    ```
+
+- GitHubUsers are members of an organization.  In some cases there may be a user who is "unaffiliated" with an org, for example if the user is an enterprise owner, but not member of, the org.
+
+    ```
+    (GitHubUser)-[MEMBER_OF|UNAFFILIATED]->(GitHubOrganization)
     ```
 
 ### GitHubBranch

--- a/tests/data/github/users.py
+++ b/tests/data/github/users.py
@@ -1,4 +1,10 @@
-GITHUB_USER_DATA = [
+GITHUB_ORG_DATA = {
+    'url': 'https://example.com/my_org',
+    'login': 'my_org',
+}
+
+
+GITHUB_USER_DATA = ([
     {
         'hasTwoFactorEnabled': None,
         'node': {
@@ -13,6 +19,17 @@ GITHUB_USER_DATA = [
     }, {
         'hasTwoFactorEnabled': None,
         'node': {
+            'url': 'https://example.com/lmsimpson',
+            'login': 'lmsimpson',
+            'name': 'Lisa Simpson',
+            'isSiteAdmin': False,
+            'email': 'lmsimpson@example.com',
+            'company': 'Simpson Residence',
+        },
+        'role': 'MEMBER',
+    }, {
+        'hasTwoFactorEnabled': True,
+        'node': {
             'url': 'https://example.com/mbsimpson',
             'login': 'mbsimpson',
             'name': 'Marge Simpson',
@@ -21,16 +38,16 @@ GITHUB_USER_DATA = [
             'company': 'Simpson Residence',
         },
         'role': 'ADMIN',
-    },
-]
+    }],
+    GITHUB_ORG_DATA
+)
 
-# Note the subtle differences between owner data and user data:
+# Subtle differences between owner data and user data:
 # 1. owner data does not include a `hasTwoFactorEnabled` field (it in unavailable in the GraphQL query for these owners)
-# 2. an `organizationRole` field instead of a `role` field.  For user data, membership in the queried org
-#    is assumed.  The owner data, membership is not assumed, so there is an 'UNAFFILIATED' value for owners who are
-#    not also users in an organization.  In this list, the 'OWNER' organizationRole matches the 'ADMIN' role in the
-#    user data.  Similarly, the 'DIRECT_MEMBER' organizationRole matches the 'MEMBER' role.
-GITHUB_ENTERPRISE_OWNER_DATA = [ # TODO put in real fake values for testing
+# 2. an `organizationRole` field instead of a `role` field.  In owner data, membership within an org is not assumed, so
+#    there is an 'UNAFFILIATED' value for owners of an org who are not also members of it.  (Otherwise the 'OWNER'
+#    organizationRole matches the 'ADMIN' role in the user data, and the 'DIRECT_MEMBER' organizationRole matches the 'MEMBER' role.)
+GITHUB_ENTERPRISE_OWNER_DATA = ([
     {
         'node': {
             'url': 'https://example.com/kbroflovski',
@@ -43,14 +60,14 @@ GITHUB_ENTERPRISE_OWNER_DATA = [ # TODO put in real fake values for testing
         'organizationRole': 'UNAFFILIATED',
     }, {
         'node': {
-            'url': 'https://example.com/bjsimpson',
-            'login': 'bjsimpson',
-            'name': 'Bartholomew Simpson',
+            'url': 'https://example.com/mbsimpson',
+            'login': 'mbsimpson',
+            'name': 'Marge Simpson',
             'isSiteAdmin': False,
-            'email': 'bjsimpson@example.com',
+            'email': 'mbsimpson@example.com',
             'company': 'Simpson Residence',
         },
-        'organizationRole': 'DIRECT_MEMBER',
+        'organizationRole': 'OWNER',
     }, {
         'node': {
             'url': 'https://example.com/lmsimpson',
@@ -60,11 +77,8 @@ GITHUB_ENTERPRISE_OWNER_DATA = [ # TODO put in real fake values for testing
             'email': 'lmsimpson@example.com',
             'company': 'Simpson Residence',
         },
-        'organizationRole': 'OWNER',
-    },
-]
+        'organizationRole': 'DIRECT_MEMBER',
+    }],
+    GITHUB_ORG_DATA
+)
 
-GITHUB_ORG_DATA = {
-    'url': 'https://example.com/my_org',
-    'login': 'my_org',
-}

--- a/tests/data/github/users.py
+++ b/tests/data/github/users.py
@@ -24,6 +24,46 @@ GITHUB_USER_DATA = [
     },
 ]
 
+# Note the subtle differences between owner data and user data:
+# 1. owner data does not include a `hasTwoFactorEnabled` field (it in unavailable in the GraphQL query for these owners)
+# 2. an `organizationRole` field instead of a `role` field.  For user data, membership in the queried org
+#    is assumed.  The owner data, membership is not assumed, so there is an 'UNAFFILIATED' value for owners who are
+#    not also users in an organization.  In this list, the 'OWNER' organizationRole matches the 'ADMIN' role in the
+#    user data.  Similarly, the 'DIRECT_MEMBER' organizationRole matches the 'MEMBER' role.
+GITHUB_ENTERPRISE_OWNER_DATA = [ # TODO put in real fake values for testing
+    {
+        'node': {
+            'url': 'https://example.com/kbroflovski',
+            'login': 'kbroflovski',
+            'name': 'Kyle Broflovski',
+            'isSiteAdmin': False,
+            'email': 'kbroflovski@example.com',
+            'company': 'South Park Elementary',
+        },
+        'organizationRole': 'UNAFFILIATED',
+    }, {
+        'node': {
+            'url': 'https://example.com/bjsimpson',
+            'login': 'bjsimpson',
+            'name': 'Bartholomew Simpson',
+            'isSiteAdmin': False,
+            'email': 'bjsimpson@example.com',
+            'company': 'Simpson Residence',
+        },
+        'organizationRole': 'DIRECT_MEMBER',
+    }, {
+        'node': {
+            'url': 'https://example.com/lmsimpson',
+            'login': 'lmsimpson',
+            'name': 'Lisa Simpson',
+            'isSiteAdmin': False,
+            'email': 'lmsimpson@example.com',
+            'company': 'Simpson Residence',
+        },
+        'organizationRole': 'OWNER',
+    },
+]
+
 GITHUB_ORG_DATA = {
     'url': 'https://example.com/my_org',
     'login': 'my_org',

--- a/tests/data/github/users.py
+++ b/tests/data/github/users.py
@@ -4,81 +4,85 @@ GITHUB_ORG_DATA = {
 }
 
 
-GITHUB_USER_DATA = ([
-    {
-        'hasTwoFactorEnabled': None,
-        'node': {
-            'url': 'https://example.com/hjsimpson',
-            'login': 'hjsimpson',
-            'name': 'Homer Simpson',
-            'isSiteAdmin': False,
-            'email': 'hjsimpson@example.com',
-            'company': 'Springfield Nuclear Power Plant',
+GITHUB_USER_DATA = (
+    [
+        {
+            'hasTwoFactorEnabled': None,
+            'node': {
+                'url': 'https://example.com/hjsimpson',
+                'login': 'hjsimpson',
+                'name': 'Homer Simpson',
+                'isSiteAdmin': False,
+                'email': 'hjsimpson@example.com',
+                'company': 'Springfield Nuclear Power Plant',
+            },
+            'role': 'MEMBER',
+        }, {
+            'hasTwoFactorEnabled': None,
+            'node': {
+                'url': 'https://example.com/lmsimpson',
+                'login': 'lmsimpson',
+                'name': 'Lisa Simpson',
+                'isSiteAdmin': False,
+                'email': 'lmsimpson@example.com',
+                'company': 'Simpson Residence',
+            },
+            'role': 'MEMBER',
+        }, {
+            'hasTwoFactorEnabled': True,
+            'node': {
+                'url': 'https://example.com/mbsimpson',
+                'login': 'mbsimpson',
+                'name': 'Marge Simpson',
+                'isSiteAdmin': False,
+                'email': 'mbsimpson@example.com',
+                'company': 'Simpson Residence',
+            },
+            'role': 'ADMIN',
         },
-        'role': 'MEMBER',
-    }, {
-        'hasTwoFactorEnabled': None,
-        'node': {
-            'url': 'https://example.com/lmsimpson',
-            'login': 'lmsimpson',
-            'name': 'Lisa Simpson',
-            'isSiteAdmin': False,
-            'email': 'lmsimpson@example.com',
-            'company': 'Simpson Residence',
-        },
-        'role': 'MEMBER',
-    }, {
-        'hasTwoFactorEnabled': True,
-        'node': {
-            'url': 'https://example.com/mbsimpson',
-            'login': 'mbsimpson',
-            'name': 'Marge Simpson',
-            'isSiteAdmin': False,
-            'email': 'mbsimpson@example.com',
-            'company': 'Simpson Residence',
-        },
-        'role': 'ADMIN',
-    }],
-    GITHUB_ORG_DATA
+    ],
+    GITHUB_ORG_DATA,
 )
 
 # Subtle differences between owner data and user data:
 # 1. owner data does not include a `hasTwoFactorEnabled` field (it in unavailable in the GraphQL query for these owners)
 # 2. an `organizationRole` field instead of a `role` field.  In owner data, membership within an org is not assumed, so
 #    there is an 'UNAFFILIATED' value for owners of an org who are not also members of it.  (Otherwise the 'OWNER'
-#    organizationRole matches the 'ADMIN' role in the user data, and the 'DIRECT_MEMBER' organizationRole matches the 'MEMBER' role.)
-GITHUB_ENTERPRISE_OWNER_DATA = ([
-    {
-        'node': {
-            'url': 'https://example.com/kbroflovski',
-            'login': 'kbroflovski',
-            'name': 'Kyle Broflovski',
-            'isSiteAdmin': False,
-            'email': 'kbroflovski@example.com',
-            'company': 'South Park Elementary',
+#    organizationRole matches the 'ADMIN' role in the user data, and the 'DIRECT_MEMBER' organizationRole matches
+#    the 'MEMBER' role.)
+GITHUB_ENTERPRISE_OWNER_DATA = (
+    [
+        {
+            'node': {
+                'url': 'https://example.com/kbroflovski',
+                'login': 'kbroflovski',
+                'name': 'Kyle Broflovski',
+                'isSiteAdmin': False,
+                'email': 'kbroflovski@example.com',
+                'company': 'South Park Elementary',
+            },
+            'organizationRole': 'UNAFFILIATED',
+        }, {
+            'node': {
+                'url': 'https://example.com/mbsimpson',
+                'login': 'mbsimpson',
+                'name': 'Marge Simpson',
+                'isSiteAdmin': False,
+                'email': 'mbsimpson@example.com',
+                'company': 'Simpson Residence',
+            },
+            'organizationRole': 'OWNER',
+        }, {
+            'node': {
+                'url': 'https://example.com/lmsimpson',
+                'login': 'lmsimpson',
+                'name': 'Lisa Simpson',
+                'isSiteAdmin': False,
+                'email': 'lmsimpson@example.com',
+                'company': 'Simpson Residence',
+            },
+            'organizationRole': 'DIRECT_MEMBER',
         },
-        'organizationRole': 'UNAFFILIATED',
-    }, {
-        'node': {
-            'url': 'https://example.com/mbsimpson',
-            'login': 'mbsimpson',
-            'name': 'Marge Simpson',
-            'isSiteAdmin': False,
-            'email': 'mbsimpson@example.com',
-            'company': 'Simpson Residence',
-        },
-        'organizationRole': 'OWNER',
-    }, {
-        'node': {
-            'url': 'https://example.com/lmsimpson',
-            'login': 'lmsimpson',
-            'name': 'Lisa Simpson',
-            'isSiteAdmin': False,
-            'email': 'lmsimpson@example.com',
-            'company': 'Simpson Residence',
-        },
-        'organizationRole': 'DIRECT_MEMBER',
-    }],
-    GITHUB_ORG_DATA
+    ],
+    GITHUB_ORG_DATA,
 )
-

--- a/tests/integration/cartography/intel/github/test_users.py
+++ b/tests/integration/cartography/intel/github/test_users.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
+
 import cartography.intel.github.users
-from tests.data.github.users import GITHUB_USER_DATA
-from tests.data.github.users import GITHUB_ORG_DATA
 from tests.data.github.users import GITHUB_ENTERPRISE_OWNER_DATA
+from tests.data.github.users import GITHUB_ORG_DATA
+from tests.data.github.users import GITHUB_USER_DATA
 
 TEST_UPDATE_TAG = 123456789
 TEST_JOB_PARAMS = {'UPDATE_TAG': TEST_UPDATE_TAG}
@@ -23,7 +24,8 @@ def test_sync(mock_owners, mock_users, neo4j_session):
         TEST_JOB_PARAMS,
         FAKE_API_KEY,
         TEST_GITHUB_URL,
-        TEST_GITHUB_ORG)
+        TEST_GITHUB_ORG,
+    )
 
     # Assert
 
@@ -103,7 +105,6 @@ def test_sync(mock_owners, mock_users, neo4j_session):
     assert actual_nodes == expected_nodes
 
     # Ensure hasTwoFactorEnabled has not been improperly overwritten for enterprise owners
-    # Ensure enterprise owners are identified
     nodes = neo4j_session.run(
         """
         MATCH (g:GitHubUser) RETURN g.id, g.has_2fa_enabled

--- a/tests/integration/cartography/intel/github/test_users.py
+++ b/tests/integration/cartography/intel/github/test_users.py
@@ -1,16 +1,31 @@
+from unittest.mock import patch
 import cartography.intel.github.users
-import tests.data.github.users
+from tests.data.github.users import GITHUB_USER_DATA
+from tests.data.github.users import GITHUB_ORG_DATA
+from tests.data.github.users import GITHUB_ENTERPRISE_OWNER_DATA
 
 TEST_UPDATE_TAG = 123456789
+TEST_JOB_PARAMS = {'UPDATE_TAG': TEST_UPDATE_TAG}
+TEST_GITHUB_URL = GITHUB_ORG_DATA['url']
+TEST_GITHUB_ORG = GITHUB_ORG_DATA['login']
+FAKE_API_KEY = 'asdf'
 
 
-def test_load_github_organization_users(neo4j_session):
-    cartography.intel.github.users.load_organization_users(
+@patch.object(cartography.intel.github.users, 'get_users', return_value=GITHUB_USER_DATA)
+@patch.object(cartography.intel.github.users, '_get_enterprise_owners_raw', return_value=GITHUB_ENTERPRISE_OWNER_DATA)
+def test_sync(mock_owners, mock_users, neo4j_session):
+    # Arrange
+    # No need to 'arrange' data here.  The patched functions return all the data needed.
+
+    # Act
+    cartography.intel.github.users.sync(
         neo4j_session,
-        tests.data.github.users.GITHUB_USER_DATA,
-        tests.data.github.users.GITHUB_ORG_DATA,
-        TEST_UPDATE_TAG,
-    )
+        TEST_JOB_PARAMS,
+        FAKE_API_KEY,
+        TEST_GITHUB_URL,
+        TEST_GITHUB_ORG)
+
+    # Assert
 
     # Ensure users got loaded
     nodes = neo4j_session.run(
@@ -20,7 +35,9 @@ def test_load_github_organization_users(neo4j_session):
     )
     expected_nodes = {
         ("https://example.com/hjsimpson", 'MEMBER'),
+        ("https://example.com/lmsimpson", 'MEMBER'),
         ("https://example.com/mbsimpson", 'ADMIN'),
+        ("https://example.com/kbroflovski", None),
     }
     actual_nodes = {
         (
@@ -33,23 +50,75 @@ def test_load_github_organization_users(neo4j_session):
     # Ensure users are connected to the expected organization
     nodes = neo4j_session.run(
         """
-        MATCH(user:GitHubUser)-[:MEMBER_OF]->(org:GitHubOrganization)
-        RETURN user.id, org.id
+        MATCH(user:GitHubUser)-[r]->(org:GitHubOrganization)
+        RETURN user.id, type(r), org.id
         """,
     )
     actual_nodes = {
         (
             n['user.id'],
+            n['type(r)'],
             n['org.id'],
         ) for n in nodes
     }
     expected_nodes = {
         (
             'https://example.com/hjsimpson',
+            'MEMBER_OF',
+            'https://example.com/my_org',
+        ), (
+            'https://example.com/lmsimpson',
+            'MEMBER_OF',
             'https://example.com/my_org',
         ), (
             'https://example.com/mbsimpson',
+            'MEMBER_OF',
+            'https://example.com/my_org',
+        ), (
+            'https://example.com/kbroflovski',
+            'UNAFFILIATED',
             'https://example.com/my_org',
         ),
+    }
+    assert actual_nodes == expected_nodes
+
+    # Ensure enterprise owners are identified
+    nodes = neo4j_session.run(
+        """
+        MATCH (g:GitHubUser) RETURN g.id, g.is_enterprise_owner
+        """,
+    )
+    expected_nodes = {
+        ("https://example.com/hjsimpson", False),
+        ("https://example.com/lmsimpson", True),
+        ("https://example.com/mbsimpson", True),
+        ("https://example.com/kbroflovski", True),
+    }
+    actual_nodes = {
+        (
+            n['g.id'],
+            n['g.is_enterprise_owner'],
+        ) for n in nodes
+    }
+    assert actual_nodes == expected_nodes
+
+    # Ensure hasTwoFactorEnabled has not been improperly overwritten for enterprise owners
+    # Ensure enterprise owners are identified
+    nodes = neo4j_session.run(
+        """
+        MATCH (g:GitHubUser) RETURN g.id, g.has_2fa_enabled
+        """,
+    )
+    expected_nodes = {
+        ("https://example.com/hjsimpson", None),
+        ("https://example.com/lmsimpson", None),
+        ("https://example.com/mbsimpson", True),
+        ("https://example.com/kbroflovski", None),
+    }
+    actual_nodes = {
+        (
+            n['g.id'],
+            n['g.has_2fa_enabled'],
+        ) for n in nodes
     }
     assert actual_nodes == expected_nodes


### PR DESCRIPTION
### Summary

This PR adds to the Github graph, marking users as [enterprise owners](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners). 

We think this is a valuable addition to the graph in general, because these users are not all necessarily visible in the graph at the moment but have broad access.  Less generally (but still maybe relevant to others) our analysts at Etsy need to review these users as part of our UAR (User Access Review) process, which we hope Cartography will eventually help to power.

We wanted to do this in a light-touch way, without breaking existing relationships or removing properties.  We also wanted to follow how similar properties are graphed on the user node: org ownership, for example, is noted by the 'user.role' property; similarly, the 'user.is_site_admin' property notes whether a user is a site admin).  To that end, we did the following:

1. add an 'is_enterprise_owner' property to all user nodes
2. add a new type of user-org relationship: 'UNAFFILIATED'.  The [terminology](https://docs.github.com/en/graphql/reference/enums#roleinorganization) is Github's, and it is used for enterprise owners who are not also members of the graphed organization.

Here is an illustration of before/after (I will also add some screencap below but thought the high-level illustration might help):
![Cartography AMPS User Owns Enterprise (1)](https://github.com/user-attachments/assets/dc943ab5-2a95-4f76-a39a-6b9f6262169b)

### Other notes on the PR

1. I refactored the integration tests, taking cues from how the testing for Github teams was done by testing the 'sync' function as a whole instead of just the 'load' function.
1. In general I tried to do things in keeping with the style I saw around me.  I am happy to change anything.
1. In our slack conversation, it was mentioned PRs should use the new models.  I’d already written this when I read that, but, when I looked I saw there are no models for this.  Is that okay?  Should they be added and, if so, could it be in a separate PR or must it be here?

### Related issues or links

None.

### Screencaps

_(I could get other screencaps... if anything would be helpful, please let me know.)_

In this case was helpful that we had an enterprise owner who was also a user in one of our orgs, but not another.  I highlighted them specifically in a query here, showing both the new property and relationship type.

**Before**
![User Org Before](https://github.com/user-attachments/assets/f21bb2a9-8d3e-45ed-bc7b-112b21bd304a)

**After**
![User Org After](https://github.com/user-attachments/assets/637eb10d-20f5-4aa6-9c3d-626b480b3014)




### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [X] Update/add unit or integration tests.
- [X] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [X] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).  **NOTE: I updated the schema but not the README, which seemed like it was out of date, did not already include github, and suggested using a javascript dependency to update it... please advise, if this needs update.** 😄 

If you are implementing a new intel module:
- **N/A** [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
