### PR TITLE
Gh user repo relationships

### DIFF
--- a/cartography/data/jobs/cleanup/github_org_and_users_cleanup.json
+++ b/cartography/data/jobs/cleanup/github_org_and_users_cleanup.json
@@ -18,6 +18,11 @@
     "query": "MATCH (:GitHubUser)-[r:MEMBER_OF]->(:GitHubOrganization) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:GitHubUser)-[r:UNAFFILIATED]->(:GitHubOrganization) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "iterative": true,
+    "iterationsize": 100
   }],
   "name": "cleanup GitHub users data"
 }

--- a/cartography/models/github/orgs.py
+++ b/cartography/models/github/orgs.py
@@ -1,0 +1,26 @@
+"""
+This schema does not handle the org's relationships.  Those are handled by other schemas, for example:
+* GitHubTeamSchema defines (GitHubOrganization)-[RESOURCE]->(GitHubTeam)
+* GitHubUserSchema defines (GitHubUser)-[MEMBER_OF|UNAFFILIATED]->(GitHubOrganization)
+(There may be others, these are just two examples.)
+"""
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+
+
+@dataclass(frozen=True)
+class GitHubOrganizationNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('url')
+    username: PropertyRef = PropertyRef('login', extra_index=True)
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubOrganizationSchema(CartographyNodeSchema):
+    label: str = 'GitHubOrganization'
+    properties: GitHubOrganizationNodeProperties = GitHubOrganizationNodeProperties()
+    other_relationships = None
+    sub_resource_relationship = None

--- a/cartography/models/github/users.py
+++ b/cartography/models/github/users.py
@@ -1,0 +1,119 @@
+"""
+RE: Tenant relationship between GitHubUser and GitHubOrganization
+
+Note this relationship is implemented via 'other_relationships' and not via the 'sub_resource_relationship'
+as might be expected.
+
+The 'sub_resource_relationship' typically describes the relationship of a node to its tenant (the org, project, or
+other resource to which other nodes belong).  An assumption of that relationship is that if the tenant goes
+away, all nodes related to it should be cleaned up.
+
+In GitHub, though the GitHubUser's tenant seems to be GitHubOrganization, users actually exist independently.  There
+is a concept of 'UNAFFILIATED' users (https://docs.github.com/en/graphql/reference/enums#roleinorganization) like
+Enterprise Owners who are related to an org even if they are not direct members of it.  You would not want them to be
+cleaned up, if an org goes away, and you could want them in your graph even if they are not members of any org in
+the enterprise.
+
+To allow for this in the schema, this relationship is treated as any other node-to-node relationship, via
+'other_relationships', instead of as the typical 'sub_resource_relationship'.
+
+RE: GitHubOrganizationUserSchema vs GitHubUnaffiliatedUserSchema
+
+As noted above, there are implicitly two types of users, those that are part of, or affiliated, to a target
+GitHubOrganization, and those thare are not part, or unaffiliated.   Both are represented as GitHubUser nodes,
+but there are two schemas below to allow for some differences between them, e.g., unaffiliated lack these properties:
+  * the 'role' property, because unaffiliated have no 'role' in the target org
+  * the 'has_2fa_enabled' property, because the GitHub api does not return it, for these users
+The main importance of having two schemas is to allow the two sets of users to be loaded separately.  If we are loading
+an unaffiliated user, but the user already exists in the graph (perhaps they are members of another GitHub orgs for
+example), then loading the unaffiliated user will not blank out the 'role' and 'has_2fa_enabled' properties.
+"""
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class BaseGitHubUserNodeProperties(CartographyNodeProperties):
+    # core properties in all GitHubUser nodes
+    id: PropertyRef = PropertyRef('url')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+    fullname: PropertyRef = PropertyRef('name')
+    username: PropertyRef = PropertyRef('login', extra_index=True)
+    is_site_admin: PropertyRef = PropertyRef('isSiteAdmin')
+    is_enterprise_owner: PropertyRef = PropertyRef('isEnterpriseOwner')
+    email: PropertyRef = PropertyRef('email')
+    company: PropertyRef = PropertyRef('company')
+
+
+@dataclass(frozen=True)
+class GitHubOrganizationUserNodeProperties(BaseGitHubUserNodeProperties):
+    # specified for affiliated users only. The GitHub api does not return this property for unaffiliated users.
+    has_2fa_enabled: PropertyRef = PropertyRef('hasTwoFactorEnabled')
+    # specified for affiliated uers only.  Unaffiliated users do not have a 'role' in the target organization.
+    role: PropertyRef = PropertyRef('role')
+
+
+@dataclass(frozen=True)
+class GitHubUnaffiliatedUserNodeProperties(BaseGitHubUserNodeProperties):
+    # No additional properties needed
+    pass
+
+
+@dataclass(frozen=True)
+class GitHubUserToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubUserMemberOfOrganizationRel(CartographyRelSchema):
+    target_node_label: str = 'GitHubOrganization'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('MEMBER_OF')},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF"
+    properties: GitHubUserToOrganizationRelProperties = GitHubUserToOrganizationRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubUserUnaffiliatedOrganizationRel(CartographyRelSchema):
+    target_node_label: str = 'GitHubOrganization'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('UNAFFILIATED')},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "UNAFFILIATED"
+    properties: GitHubUserToOrganizationRelProperties = GitHubUserToOrganizationRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubOrganizationUserSchema(CartographyNodeSchema):
+    label: str = 'GitHubUser'
+    properties: GitHubOrganizationUserNodeProperties = GitHubOrganizationUserNodeProperties()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GitHubUserMemberOfOrganizationRel(),
+        ],
+    )
+    sub_resource_relationship = None
+
+
+@dataclass(frozen=True)
+class GitHubUnaffiliatedUserSchema(CartographyNodeSchema):
+    label: str = 'GitHubUser'
+    properties: GitHubUnaffiliatedUserNodeProperties = GitHubUnaffiliatedUserNodeProperties()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GitHubUserUnaffiliatedOrganizationRel(),
+        ],
+    )
+    sub_resource_relationship = None

--- a/docs/root/modules/github/schema.md
+++ b/docs/root/modules/github/schema.md
@@ -87,6 +87,12 @@ Representation of a single GitHubOrganization [organization object](https://deve
     (GitHubOrganization)-[RESOURCE]->(GitHubTeam)
     ```
 
+- GitHubUsers are members of an organization.  In some cases there may be a user who is "unaffiliated" with an org, for example if the user is an enterprise owner, but not member of, the org.  [Enterprise owners](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners) have complete control over the enterprise (i.e. they can manage all enterprise settings, members, and policies) yet may not show up on member lists of the GitHub org.
+
+    ```
+    (GitHubUser)-[MEMBER_OF|UNAFFILIATED]->(GitHubOrganization)
+    ```
+
 
 ### GitHubTeam
 
@@ -131,10 +137,10 @@ Representation of a single GitHubUser [user object](https://developer.github.com
 | has_2fa_enabled | Whether the user has 2-factor authentication enabled |
 | role | Either 'ADMIN' (denoting that the user is an owner of a Github organization) or 'MEMBER' |
 | is_site_admin | Whether the user is a site admin |
-| permission | Only present if the user is an [outside collaborator](https://docs.github.com/en/graphql/reference/objects#repositorycollaboratorconnection) of this repo.
-`permission` is either ADMIN, MAINTAIN, READ, TRIAGE, or WRITE ([ref](https://docs.github.com/en/graphql/reference/enums#repositorypermission)).
-| email | The user's publicly visible profile email.
-| company | The user's public profile company.
+| is_enterprise_owner | Whether the user is an [enterprise owner](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners) |
+| permission | Only present if the user is an [outside collaborator](https://docs.github.com/en/graphql/reference/objects#repositorycollaboratorconnection) of this repo.  `permission` is either ADMIN, MAINTAIN, READ, TRIAGE, or WRITE ([ref](https://docs.github.com/en/graphql/reference/enums#repositorypermission)). |
+| email | The user's publicly visible profile email. |
+| company | The user's public profile company. |
 
 
 #### Relationships
@@ -150,6 +156,12 @@ WRITE, MAINTAIN, TRIAGE, and READ ([Reference](https://docs.github.com/en/graphq
 
     ```
     (GitHubUser)-[:OUTSIDE_COLLAB_{ACTION}]->(GitHubRepository)
+    ```
+
+- GitHubUsers are members of an organization.  In some cases there may be a user who is "unaffiliated" with an org, for example if the user is an enterprise owner, but not member of, the org.  [Enterprise owners](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners) have complete control over the enterprise (i.e. they can manage all enterprise settings, members, and policies) yet may not show up on member lists of the GitHub org.
+
+    ```
+    (GitHubUser)-[MEMBER_OF|UNAFFILIATED]->(GitHubOrganization)
     ```
 
 ### GitHubBranch

--- a/tests/data/github/users.py
+++ b/tests/data/github/users.py
@@ -1,30 +1,88 @@
-GITHUB_USER_DATA = [
-    {
-        'hasTwoFactorEnabled': None,
-        'node': {
-            'url': 'https://example.com/hjsimpson',
-            'login': 'hjsimpson',
-            'name': 'Homer Simpson',
-            'isSiteAdmin': False,
-            'email': 'hjsimpson@example.com',
-            'company': 'Springfield Nuclear Power Plant',
-        },
-        'role': 'MEMBER',
-    }, {
-        'hasTwoFactorEnabled': None,
-        'node': {
-            'url': 'https://example.com/mbsimpson',
-            'login': 'mbsimpson',
-            'name': 'Marge Simpson',
-            'isSiteAdmin': False,
-            'email': 'mbsimpson@example.com',
-            'company': 'Simpson Residence',
-        },
-        'role': 'ADMIN',
-    },
-]
-
 GITHUB_ORG_DATA = {
     'url': 'https://example.com/my_org',
     'login': 'my_org',
 }
+
+
+GITHUB_USER_DATA = (
+    [
+        {
+            'hasTwoFactorEnabled': None,
+            'node': {
+                'url': 'https://example.com/hjsimpson',
+                'login': 'hjsimpson',
+                'name': 'Homer Simpson',
+                'isSiteAdmin': False,
+                'email': 'hjsimpson@example.com',
+                'company': 'Springfield Nuclear Power Plant',
+            },
+            'role': 'MEMBER',
+        }, {
+            'hasTwoFactorEnabled': None,
+            'node': {
+                'url': 'https://example.com/lmsimpson',
+                'login': 'lmsimpson',
+                'name': 'Lisa Simpson',
+                'isSiteAdmin': False,
+                'email': 'lmsimpson@example.com',
+                'company': 'Simpson Residence',
+            },
+            'role': 'MEMBER',
+        }, {
+            'hasTwoFactorEnabled': True,
+            'node': {
+                'url': 'https://example.com/mbsimpson',
+                'login': 'mbsimpson',
+                'name': 'Marge Simpson',
+                'isSiteAdmin': False,
+                'email': 'mbsimpson@example.com',
+                'company': 'Simpson Residence',
+            },
+            'role': 'ADMIN',
+        },
+    ],
+    GITHUB_ORG_DATA,
+)
+
+# Subtle differences between owner data and user data:
+# 1. owner data does not include a `hasTwoFactorEnabled` field (it in unavailable in the GraphQL query for these owners)
+# 2. an `organizationRole` field instead of a `role` field.  In owner data, membership within an org is not assumed, so
+#    there is an 'UNAFFILIATED' value for owners of an org who are not also members of it.  (Otherwise the 'OWNER'
+#    organizationRole matches the 'ADMIN' role in the user data, and the 'DIRECT_MEMBER' organizationRole matches
+#    the 'MEMBER' role.)
+GITHUB_ENTERPRISE_OWNER_DATA = (
+    [
+        {
+            'node': {
+                'url': 'https://example.com/kbroflovski',
+                'login': 'kbroflovski',
+                'name': 'Kyle Broflovski',
+                'isSiteAdmin': False,
+                'email': 'kbroflovski@example.com',
+                'company': 'South Park Elementary',
+            },
+            'organizationRole': 'UNAFFILIATED',
+        }, {
+            'node': {
+                'url': 'https://example.com/mbsimpson',
+                'login': 'mbsimpson',
+                'name': 'Marge Simpson',
+                'isSiteAdmin': False,
+                'email': 'mbsimpson@example.com',
+                'company': 'Simpson Residence',
+            },
+            'organizationRole': 'OWNER',
+        }, {
+            'node': {
+                'url': 'https://example.com/lmsimpson',
+                'login': 'lmsimpson',
+                'name': 'Lisa Simpson',
+                'isSiteAdmin': False,
+                'email': 'lmsimpson@example.com',
+                'company': 'Simpson Residence',
+            },
+            'organizationRole': 'DIRECT_MEMBER',
+        },
+    ],
+    GITHUB_ORG_DATA,
+)

--- a/tests/data/graph/querybuilder/sample_data/case_insensitive_prop_ref.py
+++ b/tests/data/graph/querybuilder/sample_data/case_insensitive_prop_ref.py
@@ -1,33 +1,34 @@
-FAKE_GITHUB_USER_DATA = [
-    {
-        'hasTwoFactorEnabled': None,
-        'node': {
-            'url': 'https://example.com/hjsimpson',
-            'login': 'HjsimPson',  # Upper and lowercase
-            'name': 'Homer Simpson',
-            'isSiteAdmin': False,
-            'email': 'hjsimpson@example.com',
-            'company': 'Springfield Nuclear Power Plant',
-        },
-        'role': 'MEMBER',
-    }, {
-        'hasTwoFactorEnabled': None,
-        'node': {
-            'url': 'https://example.com/mbsimpson',
-            'login': 'mbsimp-son',  # All lowercase
-            'name': 'Marge Simpson',
-            'isSiteAdmin': False,
-            'email': 'mbsimpson@example.com',
-            'company': 'Simpson Residence',
-        },
-        'role': 'ADMIN',
-    },
-]
-
 FAKE_GITHUB_ORG_DATA = {
     'url': 'https://example.com/my_org',
     'login': 'my_org',
 }
+
+FAKE_GITHUB_USER_DATA = [
+    {
+        'MEMBER_OF': FAKE_GITHUB_ORG_DATA['url'],
+        'hasTwoFactorEnabled': None,
+        'url': 'https://example.com/hjsimpson',
+        'login': 'HjsimPson',  # Upper and lowercase
+        'name': 'Homer Simpson',
+        'isSiteAdmin': False,
+        'isEnterpriseOwner': False,
+        'email': 'hjsimpson@example.com',
+        'company': 'Springfield Nuclear Power Plant',
+        'role': 'MEMBER',
+    }, {
+        'MEMBER_OF': FAKE_GITHUB_ORG_DATA['url'],
+        'hasTwoFactorEnabled': None,
+        'url': 'https://example.com/mbsimpson',
+        'login': 'mbsimp-son',  # All lowercase
+        'name': 'Marge Simpson',
+        'isEnterpriseOwner': True,
+        'isSiteAdmin': False,
+        'email': 'mbsimpson@example.com',
+        'company': 'Simpson Residence',
+        'role': 'ADMIN',
+    },
+]
+
 
 FAKE_EMPLOYEE_DATA = [
     {

--- a/tests/integration/cartography/graph/test_querybuilder_case_insensitive.py
+++ b/tests/integration/cartography/graph/test_querybuilder_case_insensitive.py
@@ -1,5 +1,6 @@
 from cartography.client.core.tx import load
-from cartography.intel.github.users import load_organization_users
+from cartography.intel.github.users import load_users
+from cartography.models.github.users import GitHubOrganizationUserSchema
 from tests.data.graph.querybuilder.sample_data.case_insensitive_prop_ref import FAKE_EMPLOYEE_DATA
 from tests.data.graph.querybuilder.sample_data.case_insensitive_prop_ref import FAKE_GITHUB_ORG_DATA
 from tests.data.graph.querybuilder.sample_data.case_insensitive_prop_ref import FAKE_GITHUB_USER_DATA
@@ -11,8 +12,9 @@ TEST_UPDATE_TAG = 123456789
 
 def test_load_team_members_data(neo4j_session):
     # Arrange: Load some fake GitHubUser nodes to the graph
-    load_organization_users(
+    load_users(
         neo4j_session,
+        GitHubOrganizationUserSchema(),
         FAKE_GITHUB_USER_DATA,
         FAKE_GITHUB_ORG_DATA,
         TEST_UPDATE_TAG,

--- a/tests/integration/cartography/graph/test_querybuilder_fuzzy_case_insensitive.py
+++ b/tests/integration/cartography/graph/test_querybuilder_fuzzy_case_insensitive.py
@@ -1,5 +1,6 @@
 from cartography.client.core.tx import load
-from cartography.intel.github.users import load_organization_users
+from cartography.intel.github.users import load_users
+from cartography.models.github.users import GitHubOrganizationUserSchema
 from tests.data.graph.querybuilder.sample_data.case_insensitive_prop_ref import FAKE_EMPLOYEE2_DATA
 from tests.data.graph.querybuilder.sample_data.case_insensitive_prop_ref import FAKE_GITHUB_ORG_DATA
 from tests.data.graph.querybuilder.sample_data.case_insensitive_prop_ref import FAKE_GITHUB_USER_DATA
@@ -11,8 +12,9 @@ TEST_UPDATE_TAG = 123456789
 
 def test_load_team_members_data_fuzzy(neo4j_session):
     # Arrange: Load some fake GitHubUser nodes to the graph
-    load_organization_users(
+    load_users(
         neo4j_session,
+        GitHubOrganizationUserSchema(),
         FAKE_GITHUB_USER_DATA,
         FAKE_GITHUB_ORG_DATA,
         TEST_UPDATE_TAG,

--- a/tests/integration/cartography/intel/github/test_users.py
+++ b/tests/integration/cartography/intel/github/test_users.py
@@ -1,16 +1,33 @@
+from unittest.mock import patch
+
 import cartography.intel.github.users
-import tests.data.github.users
+from tests.data.github.users import GITHUB_ENTERPRISE_OWNER_DATA
+from tests.data.github.users import GITHUB_ORG_DATA
+from tests.data.github.users import GITHUB_USER_DATA
 
 TEST_UPDATE_TAG = 123456789
+TEST_JOB_PARAMS = {'UPDATE_TAG': TEST_UPDATE_TAG}
+TEST_GITHUB_URL = GITHUB_ORG_DATA['url']
+TEST_GITHUB_ORG = GITHUB_ORG_DATA['login']
+FAKE_API_KEY = 'asdf'
 
 
-def test_load_github_organization_users(neo4j_session):
-    cartography.intel.github.users.load_organization_users(
+@patch.object(cartography.intel.github.users, 'get_users', return_value=GITHUB_USER_DATA)
+@patch.object(cartography.intel.github.users, 'get_enterprise_owners', return_value=GITHUB_ENTERPRISE_OWNER_DATA)
+def test_sync(mock_owners, mock_users, neo4j_session):
+    # Arrange
+    # No need to 'arrange' data here.  The patched functions return all the data needed.
+
+    # Act
+    cartography.intel.github.users.sync(
         neo4j_session,
-        tests.data.github.users.GITHUB_USER_DATA,
-        tests.data.github.users.GITHUB_ORG_DATA,
-        TEST_UPDATE_TAG,
+        TEST_JOB_PARAMS,
+        FAKE_API_KEY,
+        TEST_GITHUB_URL,
+        TEST_GITHUB_ORG,
     )
+
+    # Assert
 
     # Ensure users got loaded
     nodes = neo4j_session.run(
@@ -20,7 +37,9 @@ def test_load_github_organization_users(neo4j_session):
     )
     expected_nodes = {
         ("https://example.com/hjsimpson", 'MEMBER'),
+        ("https://example.com/lmsimpson", 'MEMBER'),
         ("https://example.com/mbsimpson", 'ADMIN'),
+        ("https://example.com/kbroflovski", None),
     }
     actual_nodes = {
         (
@@ -33,23 +52,74 @@ def test_load_github_organization_users(neo4j_session):
     # Ensure users are connected to the expected organization
     nodes = neo4j_session.run(
         """
-        MATCH(user:GitHubUser)-[:MEMBER_OF]->(org:GitHubOrganization)
-        RETURN user.id, org.id
+        MATCH(user:GitHubUser)-[r]->(org:GitHubOrganization)
+        RETURN user.id, type(r), org.id
         """,
     )
     actual_nodes = {
         (
             n['user.id'],
+            n['type(r)'],
             n['org.id'],
         ) for n in nodes
     }
     expected_nodes = {
         (
             'https://example.com/hjsimpson',
+            'MEMBER_OF',
+            'https://example.com/my_org',
+        ), (
+            'https://example.com/lmsimpson',
+            'MEMBER_OF',
             'https://example.com/my_org',
         ), (
             'https://example.com/mbsimpson',
+            'MEMBER_OF',
+            'https://example.com/my_org',
+        ), (
+            'https://example.com/kbroflovski',
+            'UNAFFILIATED',
             'https://example.com/my_org',
         ),
+    }
+    assert actual_nodes == expected_nodes
+
+    # Ensure enterprise owners are identified
+    nodes = neo4j_session.run(
+        """
+        MATCH (g:GitHubUser) RETURN g.id, g.is_enterprise_owner
+        """,
+    )
+    expected_nodes = {
+        ("https://example.com/hjsimpson", False),
+        ("https://example.com/lmsimpson", True),
+        ("https://example.com/mbsimpson", True),
+        ("https://example.com/kbroflovski", True),
+    }
+    actual_nodes = {
+        (
+            n['g.id'],
+            n['g.is_enterprise_owner'],
+        ) for n in nodes
+    }
+    assert actual_nodes == expected_nodes
+
+    # Ensure hasTwoFactorEnabled has not been improperly overwritten for enterprise owners
+    nodes = neo4j_session.run(
+        """
+        MATCH (g:GitHubUser) RETURN g.id, g.has_2fa_enabled
+        """,
+    )
+    expected_nodes = {
+        ("https://example.com/hjsimpson", None),
+        ("https://example.com/lmsimpson", None),
+        ("https://example.com/mbsimpson", True),
+        ("https://example.com/kbroflovski", None),
+    }
+    actual_nodes = {
+        (
+            n['g.id'],
+            n['g.has_2fa_enabled'],
+        ) for n in nodes
     }
     assert actual_nodes == expected_nodes


### PR DESCRIPTION
Desciption TBD.  This is currently on hold as we work on another PR (https://github.com/cartography-cncf/cartography/pull/1378).

High level is this the feature where we will add in _direct_ user to repo access (so, not access via team membership)

**Note** this is a local PR, for our fork only.  The idea is to **NOT MERGE THIS**.  Instead, once we are ready, we close this PR and open a new one pointing to upstream, and share it with them.  Then they will review, approve, merge, and then we can pull in the latest from their master to ours.